### PR TITLE
Upstream mbkuhn docs walkthrough

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             doxygen graphviz
           python3 -m pip install --upgrade pip
-          pip3 install sphinx sphinx_rtd_theme sphinx_toolbox
+          pip3 install sphinx sphinx_rtd_theme sphinx_toolbox sphinx_copybutton
       - name: Build
         # execute from top-level amr-wind directory
         run: |

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -29,7 +29,7 @@ import sys
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [ 'sphinx.ext.mathjax', 'sphinx_toolbox.collapse']
+extensions = [ 'sphinx.ext.mathjax', 'sphinx_toolbox.collapse', 'sphinx_copybutton']
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/sphinx/walkthrough/spinup_inp.txt
+++ b/docs/sphinx/walkthrough/spinup_inp.txt
@@ -74,7 +74,7 @@ sampling.xy-domain.num_points            = 256 256
 sampling.xy-domain.origin                = 0.0 0.0 86.5      
 sampling.xy-domain.axis1                 = 2550.0 0.0 0.0      
 sampling.xy-domain.axis2                 = 0.0 2550.0 0.0      
-sampling.xy-domain.normal                = 0.0 0.0 1.0         
+sampling.xy-domain.offset_vector         = 0.0 0.0 1.0         
 sampling.xy-domain.offsets               = -63.45 0.0 63.45  
 
 sampling.xz-domain.type                  = PlaneSampler        


### PR DESCRIPTION
Adding copy button functionality to documentation, and updating a deprecated functionality in the the spinup inputs file.
